### PR TITLE
Be more pedantic about return type

### DIFF
--- a/fizzbuzz/c/fizzbuzz.c
+++ b/fizzbuzz/c/fizzbuzz.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-main() {
+int main() {
   int i;
   for (i = 1; i<101; i++) {
     if (i % 15 == 0) {
@@ -13,4 +13,5 @@ main() {
       printf("%d\n", i);
     }
   }
+  return 0;
 }


### PR DESCRIPTION
Just silencing pesky warning related to 'main' return types. I like it clean in 'hard' languages :)

``` bash
gcc -std=c99 -Wall -pedantic fizzbuzz.c
fizzbuzz.c:3: warning: return type defaults to ‘int’
```
